### PR TITLE
Remove the version-specific python-dateutil logic.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,6 @@ def get_version():
         return VERSION
     raise RuntimeError('No version info found.')
 
-
-def get_dependencies():
-    deps = ['pytz']
-    if sys.version_info[0] == 3:  # Python >= 3
-        deps.append('python-dateutil >= 2')
-    else:
-        deps.append('python-dateutil < 2')
-    return deps
-
 setup(
     name='times',
     version=get_version(),
@@ -35,7 +26,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=get_dependencies(),
+    install_requires=['pytz', 'python-dateutil'],
     classifiers=[
         # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers
         #'Development Status :: 1 - Planning',


### PR DESCRIPTION
python-dateutil 2.1 is compatible with both Python 2.x and 3.x (with
help from the six package).
