### PR TITLE
Generate coverage data and prepare integration with Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ python:
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install -r py26-requirements.txt; fi
   - pip install -r requirements.txt
+  - pip install coveralls --use-mirrors
   #- pip install nose  # installed by Travis by default already
 script:
-  - nosetests
+  - nosetests --with-coverage --cover-erase --cover-package=times
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Times
 =====
 
-Build status:  
-[![Build Status](https://secure.travis-ci.org/nvie/times.png)](http://travis-ci.org/nvie/times)
+Build status:
+[![Build Status](https://secure.travis-ci.org/nvie/times.png)](http://travis-ci.org/nvie/times) [![Coverage Status](https://coveralls.io/repos/nvie/times/badge.png?branch=master)](https://coveralls.io/r/nvie/times?branch=master)
+
 
 Times is a small, minimalistic, Python library for dealing with time
 conversions to and from timezones, for once and for all.

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,13 @@
 envlist = py26,py27,py32,py33,pypy
 
 [testenv]
-deps=nose
-commands=nosetests
+deps =
+    nose
+    coverage
+commands = nosetests --with-coverage --cover-erase --cover-package=times
 
 [testenv:py26]
-deps=
+deps =
     nose
+    coverage
     unittest2


### PR DESCRIPTION
I've updated the Travis build file and the Tox config to run nosetests
with the --with-coverage parameter. The resulting coverage information
can then be automatically submitted to Coveralls.io after each Travis
build (via the coveralls module).

I've also embedded a coverage badge to README.md so that we get a nice
coverage status once the repo is connected to Coveralls, i.e. something like 
this ![coverage](https://coveralls.io/repos/dbader/schedule/badge.png)

This builds and tests successfully on py26, py27, py32, py33, and pypy.

All that's left to do for coverage data to appear is: 
- Connect the `nvie/times` repo to Coveralls via [this link](https://coveralls.io/repos/new)
- Trigger a build
