### PR TITLE
Update setup.py to work around a bug where pytz doesn't install on pip >= 1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=['pytz', 'python-dateutil >= 2.1'],
+    install_requires=['pytz >= 0a', 'python-dateutil >= 2.1'],
     classifiers=[
         # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers
         #'Development Status :: 1 - Planning',


### PR DESCRIPTION
`times` doesn't install properly on pip >= 1.4. More relevant discussions on this bug https://github.com/pypa/pip/issues/974 and https://github.com/mitsuhiko/babel/issues/32 
